### PR TITLE
Improve error handling in market data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ Ensure `requests` is installed:
 ```
 pip install requests
 ```
+
+The helper function `fetch_market_chart` gracefully handles network errors. If
+the request fails, it prints an error message and returns empty lists so the
+rest of the analysis can continue (yielding zero correlations).

--- a/usdt_dominance.py
+++ b/usdt_dominance.py
@@ -28,6 +28,24 @@ def get_top_coins_market_data(limit: int = 300):
     return coins[:limit]
 
 
+def fetch_market_chart(coin_id: str, days: int = 30):
+    """Fetch historical market chart data for a coin.
+
+    On network failure the function prints an error and returns two empty
+    lists so any correlation calculations can safely proceed with zero data.
+    """
+    url = f"{COINGECKO_BASE}/coins/{coin_id}/market_chart?vs_currency=usd&days={days}"
+    try:
+        resp = requests.get(url)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"Failed to fetch market chart for {coin_id}: {exc}")
+        return [], []
+
+    data = resp.json()
+    return data.get("prices", []), data.get("market_caps", [])
+
+
 def average_change_24h(coins) -> float:
     """Compute average 24h price change percentage for given coins."""
     return mean(c.get("price_change_percentage_24h", 0.0) for c in coins)


### PR DESCRIPTION
## Summary
- add `fetch_market_chart` helper
- handle `requests.RequestException` when downloading market charts
- document new behavior in README

## Testing
- `python3 -m py_compile usdt_dominance.py`
- `python3 usdt_dominance.py bitcoin | head -n 5`
- `python3 - <<'PY'
from usdt_dominance import fetch_market_chart
prices, caps = fetch_market_chart('invalid_coin')
print(prices, caps)
PY`

------
https://chatgpt.com/codex/tasks/task_e_687108599b30832a94297fef39ff630e