### PR TITLE
Update README for requests dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python3 usdt_dominance.py [coin_id]
 `coin_id` defaults to `bitcoin` if not provided. Use a CoinGecko coin ID
 (e.g. `ethereum`, `solana`, etc.).
 
-Ensure `requests` is installed:
+The only required package is `requests`. Install it with:
 
 ```
 pip install requests


### PR DESCRIPTION
## Summary
- clarify the sole dependency in README
- show updated pip install command

## Testing
- `python3 -m py_compile usdt_dominance.py`


------
https://chatgpt.com/codex/tasks/task_e_687108575dec832aa1b6cf13488715ff