### PR TITLE
Improve API error handling and add tests

### DIFF
--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,27 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import requests
+import usdt_dominance
+
+
+def test_usdt_dominance_failure(monkeypatch, capsys):
+    def fake_get(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(usdt_dominance.requests, "get", fake_get)
+    result = usdt_dominance.get_usdt_dominance()
+    captured = capsys.readouterr()
+    assert result == 0.0
+    assert "Failed to fetch USDT dominance" in captured.out
+
+
+def test_top_coins_market_data_failure(monkeypatch, capsys):
+    def fake_get(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(usdt_dominance.requests, "get", fake_get)
+    result = usdt_dominance.get_top_coins_market_data()
+    captured = capsys.readouterr()
+    assert result == []
+    assert "Failed to fetch market data" in captured.out

--- a/usdt_dominance.py
+++ b/usdt_dominance.py
@@ -6,8 +6,14 @@ COINGECKO_BASE = "https://api.coingecko.com/api/v3"
 
 def get_usdt_dominance() -> float:
     """Fetch current USDT market cap percentage from CoinGecko."""
-    resp = requests.get(f"{COINGECKO_BASE}/global")
-    resp.raise_for_status()
+    url = f"{COINGECKO_BASE}/global"
+    try:
+        resp = requests.get(url)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"Failed to fetch USDT dominance: {exc}")
+        return 0.0
+
     data = resp.json()
     return data["data"]["market_cap_percentage"].get("usdt", 0.0)
 
@@ -22,8 +28,13 @@ def get_top_coins_market_data(limit: int = 300):
             f"{COINGECKO_BASE}/coins/markets?vs_currency=usd&order=market_cap_desc"
             f"&per_page={page_limit}&page={page}"
         )
-        resp = requests.get(url)
-        resp.raise_for_status()
+        try:
+            resp = requests.get(url)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            print(f"Failed to fetch market data page {page}: {exc}")
+            return []
+
         coins.extend(resp.json())
     return coins[:limit]
 


### PR DESCRIPTION
## Summary
- handle network failures in `get_usdt_dominance`
- handle network failures in `get_top_coins_market_data`
- add unit tests covering these failure cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687158293de0832a96ccf4eb467cb9f1